### PR TITLE
Fix random receive-timeout-sized delays on receive

### DIFF
--- a/socket.egg
+++ b/socket.egg
@@ -13,6 +13,7 @@
                        (source-dependencies "socket.scm")
                        (component-dependencies socket-config.scm)
                        (csc-options "-O2" "-d1"
+                                    "-disable-interrupts"
                                     "-X" "socket-config"
                                     "-X" "feature-test-syntax"
                                     "-D" "scan-buffer-line-returns-3-vals")))

--- a/socket.egg
+++ b/socket.egg
@@ -5,13 +5,13 @@
 (license "BSD")
 (category net)
 (version "0.3.3")
-(components (generated-source-file socket-config
+(components (generated-source-file socket-config.scm
                                    (custom-build "build-socket-config")
                                    (source-dependencies "socket-features.scm"))
             (extension socket
                        (source "socket-mod.scm")
                        (source-dependencies "socket.scm")
-                       (component-dependencies socket-config)
+                       (component-dependencies socket-config.scm)
                        (csc-options "-O2" "-d1"
                                     "-X" "socket-config"
                                     "-X" "feature-test-syntax"


### PR DESCRIPTION
This stops the possibility of the thread being interrupted between the call to `thread-block-for-timeout!` and `thread-block-for-i/o!`, causing a random 60 second delay on receive. Preferably this would be limited to `block-for-timeout!` only, but that's not easily possible.